### PR TITLE
MediaSession action handlers

### DIFF
--- a/vue_components/src/components/MediaPlayer.vue
+++ b/vue_components/src/components/MediaPlayer.vue
@@ -241,11 +241,6 @@ export default {
         nextMedia: this.nextMedia,
         elapsedTime: this.$refs.audio_player.currentTime
       });
-      navigator.mediaSession.setPositionState({
-        duration: this.$refs.audio_player.duration,
-        playbackRate: this.$refs.audio_player.playbackRate,
-        position: this.$refs.audio_player.currentTime,
-      });
     },
     status() {
       return {
@@ -265,6 +260,13 @@ export default {
       console.log("Start initial playback", this.$refs.audio_player.paused);
       this.initialPlaybackStarted = true;
       this.$emit("initial-playback-started");
+    },
+    updateMediaSession() {
+      navigator.mediaSession.setPositionState({
+        duration: this.$refs.audio_player.duration,
+        playbackRate: this.$refs.audio_player.playbackRate,
+        position: this.$refs.audio_player.currentTime,
+      });
     }
   },
   mounted() {
@@ -291,6 +293,7 @@ export default {
         this.$refs.audio_player.currentTime = this.$refs.audio_player.currentTime + 10;
       });
     }
+    setInterval(this.updateMediaSession, 1000);
   },
 };
 </script>

--- a/vue_components/src/components/MediaPlayer.vue
+++ b/vue_components/src/components/MediaPlayer.vue
@@ -208,6 +208,7 @@ export default {
       }
       navigator.mediaSession.metadata = new window.MediaMetadata({
         title: this.currentMedia.title,
+        artist: this.currentMedia.artist,
         artwork: [{src: this.currentMedia.thumbnail}]
       });
     },
@@ -240,6 +241,11 @@ export default {
         nextMedia: this.nextMedia,
         elapsedTime: this.$refs.audio_player.currentTime
       });
+      navigator.mediaSession.setPositionState({
+        duration: this.$refs.audio_player.duration,
+        playbackRate: this.$refs.audio_player.playbackRate,
+        position: this.$refs.audio_player.currentTime,
+      });
     },
     status() {
       return {
@@ -270,6 +276,20 @@ export default {
     }
     if (this.isMobile) {
       this.audioOnly = true;
+    }
+    if (!this.remoteStatus) {
+      navigator.mediaSession.setActionHandler('previoustrack', () => {
+        this.$refs.audio_player.currentTime = 0;
+      });
+      navigator.mediaSession.setActionHandler('nexttrack', () => {
+        this.$refs.audio_player.currentTime = this.$refs.audio_player.duration;
+      });
+      navigator.mediaSession.setActionHandler('seekbackward', () => {
+        this.$refs.audio_player.currentTime = this.$refs.audio_player.currentTime - 10;
+      });
+      navigator.mediaSession.setActionHandler('seekforward', () => {
+        this.$refs.audio_player.currentTime = this.$refs.audio_player.currentTime + 10;
+      });
     }
   },
 };

--- a/vue_components/src/pages/play_dynamic_playlist_host.vue
+++ b/vue_components/src/pages/play_dynamic_playlist_host.vue
@@ -19,7 +19,7 @@
   <MediaPlayer
       ref="mediaPlayer"
       :next-media-prop="nextMedia"
-      :media-playing-event-timing="8"
+      :media-playing-event-timing="1"
       :is-mobile="this.$window.context.isMobile"
       @media-playing="onMediaPlaying"
       @media-started="onMediaStarted"

--- a/vue_components/src/pages/play_dynamic_playlist_host.vue
+++ b/vue_components/src/pages/play_dynamic_playlist_host.vue
@@ -19,7 +19,7 @@
   <MediaPlayer
       ref="mediaPlayer"
       :next-media-prop="nextMedia"
-      :media-playing-event-timing="1"
+      :media-playing-event-timing="8"
       :is-mobile="this.$window.context.isMobile"
       @media-playing="onMediaPlaying"
       @media-started="onMediaStarted"


### PR DESCRIPTION
Add media session actions handlers for next/previous track and seeking, allowing control of the player by browser, OS or other software using this system
(only enabled for host user)

Also send song timing and position to the media session state

![image](https://github.com/Evanaellio/melting-potlist/assets/505052/6f60cd02-277f-4932-9b4f-448e964579a9)

